### PR TITLE
docker: reduce images size

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: hadolint/hadolint-action@v3.0.0
         with:
           recursive: true
-          ignore: DL3041
+          ignore: DL3018
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.4
+FROM docker.io/library/golang:1.19.4 as builder
 
 WORKDIR /app
-
-# install curl (healthcheck)
-RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.7
 
 # Download necessary Go modules
 COPY go.mod ./
@@ -16,8 +12,15 @@ RUN go mod download
 
 # build an app
 COPY *.go ./
-RUN go build -v -buildmode=plugin -o /opi-smbios-bridge.so ./inventory.go
+RUN go build -v -buildmode=plugin  -o /opi-smbios-bridge.so ./inventory.go \
+ && go build -v -buildmode=default -o /opi-smbios-bridge    ./main.go
 
+# second stage to reduce image size
+FROM alpine:3.17
+RUN apk add --no-cache libc6-compat
+COPY --from=builder /opi-smbios-bridge /
+COPY --from=builder /opi-smbios-bridge.so /
+COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
-CMD [ "go", "run", "main.go", "-port=50051" ]
+CMD [ "/opi-smbios-bridge", "-port=50051" ]
 HEALTHCHECK CMD grpcurl -plaintext localhost:50051 list || exit 1


### PR DESCRIPTION
By introducing multi-stage build
And switching to alpine
And using grpcurl from docker

x20 size reduction !
```
$ docker images | grep smbios
ghcr.io/opiproject/opi-smbios-bridge   main            f5c93b419b0a   3 hours ago     1.55GB
opi-smbios-bridge                      main            dd66706d37d1   12 days ago     73.1MB
```
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
