### PR TITLE
go build in default mode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
         go-version: ${{ matrix.go-version }}
 
     - name: Build
-      run: go build -v -buildmode=plugin ./...
+      run: go build -v ./...
       working-directory: cmd
 
     - name: Test


### PR DESCRIPTION
for ci we don't need plugin mode