### PR TITLE
ci: Install additional kernel modules needed for OPI like VRF

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,6 +76,9 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2.5.0
 
+      - name: Install additional kernel modules needed for OPI like VRF
+        run: sudo apt-get install linux-modules-extra-$(uname -r)
+
       - name: Start containers
         run: docker-compose up --build --force-recreate --detach opi-test
 


### PR DESCRIPTION
adding this here because we re-using workflows
and for now I can't add step on the same machine when reusing workflows steps re-use is not supported

adding those extra kernel modules will help us in EVPN repo for example to insert VRF module

without this I see
```
modprobe -v vrf
modprobe: FATAL: Module vrf not found in directory /lib/modules/5.15.0-1036-azure
```