### PR TITLE
ci: add permissions to run docker release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,5 +10,9 @@ permissions:
 
 jobs:
   release-docker:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit


### PR DESCRIPTION
Forgotten permissions to build docker image in release