### PR TITLE
feat: add grpc gw http listener

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ RUN apk add --no-cache --no-check-certificate hwdata && rm -rf /var/cache/apk/*
 COPY --from=builder /opi-smbios-bridge /
 COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
-CMD [ "/opi-smbios-bridge", "-port=50051" ]
+CMD [ "/opi-smbios-bridge", "-grpc_port=50051", "-http_port=8082" ]
 HEALTHCHECK CMD grpcurl -plaintext localhost:50051 list || exit 1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ service InventorySvc {
 }
 ```
 
+HTTP example using grpc gateway
+
+```bash
+curl -kL http://10.10.10.10:8082/v1/inventory/1/inventory/2
+```
+
 ### Nvidia example
 
 ```bash

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,25 +5,38 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
 	"net"
+	"net/http"
+	"time"
 
 	pc "github.com/opiproject/opi-api/common/v1/gen/go"
 	"github.com/opiproject/opi-smbios-bridge/pkg/inventory"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 )
 
 var (
-	port = flag.Int("port", 50051, "The server port")
+	grpcPort = flag.Int("grpc_port", 50051, "The gRPC server port")
+	httpPort = flag.Int("http_port", 8082, "The HTTP server port")
 )
 
 func main() {
 	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
+
+	go runGatewayServer()
+	runGrpcServer()
+}
+
+func runGrpcServer() {
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *grpcPort))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
@@ -32,8 +45,36 @@ func main() {
 	pc.RegisterInventorySvcServer(s, &inventory.Server{})
 	reflection.Register(s)
 
-	log.Printf("Server listening at %v", lis.Addr())
+	log.Printf("gRPC Server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
+	}
+}
+
+func runGatewayServer() {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Register gRPC server endpoint
+	// Note: Make sure the gRPC server is running properly and accessible
+	mux := runtime.NewServeMux()
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	err := pc.RegisterInventorySvcHandlerFromEndpoint(ctx, mux, fmt.Sprintf(":%d", *grpcPort), opts)
+	if err != nil {
+		log.Panic("cannot register handler server")
+	}
+
+	// Start HTTP server (and proxy calls to gRPC server endpoint)
+	log.Printf("HTTP Server listening at %v", *httpPort)
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%d", *httpPort),
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	err = server.ListenAndServe()
+	if err != nil {
+		log.Panic("cannot start HTTP gateway server")
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,20 +9,30 @@ services:
     build:
       context: .
     ports:
+      - "8082:8082"
       - "50051:50051"
     networks:
       - opi
-    command: /opi-smbios-bridge -port=50051
+    command: /opi-smbios-bridge -grpc_port=50051 -http_port=8082
     healthcheck:
       test: grpcurl -plaintext localhost:50051 list || exit 1
+
+  opi-gw-test:
+    image: curlimages/curl:8.2.1
+    networks:
+      - opi
+    depends_on:
+      opi-smbios-server:
+        condition: service_healthy
+    command: curl -qkL http://opi-smbios-server:8082/v1/inventory/1/inventory/2
 
   opi-test:
     image: namely/grpc-cli
     networks:
       - opi
     depends_on:
-      opi-smbios-server:
-        condition: service_healthy
+      - opi-gw-test
+      - opi-smbios-server
     command: call --json_input --json_output opi-smbios-server:50051 GetInventory "{}"
 
 networks:

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,8 @@ require (
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto v0.0.0-20230803162519-f966b187b2e5 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230911183012-2d3300fd4832 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230911183012-2d3300fd4832 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,12 +169,16 @@ google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98/go.mod h1:rsr7RhLuwsDKL7RmgDDCUc6yaGr1iqceVb5Wv6f6YvQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d h1:DoPTO70H+bcDXcd39vOqb2viZxgqeBeSGtZ55yZU4/Q=
 google.golang.org/genproto/googleapis/api v0.0.0-20230822172742-b8732ec3820d/go.mod h1:KjSP20unUpOx5kyQUFa7k4OJg0qeJ7DEZflGDu2p6Bk=
+google.golang.org/genproto/googleapis/api v0.0.0-20230911183012-2d3300fd4832 h1:4E7rZzBdR5LmiZx6n47Dg4AjH8JLhMQWywsYqvXNLcs=
+google.golang.org/genproto/googleapis/api v0.0.0-20230911183012-2d3300fd4832/go.mod h1:KjSP20unUpOx5kyQUFa7k4OJg0qeJ7DEZflGDu2p6Bk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 h1:0nDDozoAU19Qb2HwhXadU8OcsiO/09cnTqhUtq2MEOM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 h1:bVf09lpb+OJbByTj913DRJioFFAjf/ZGxEz7MajTp2U=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98/go.mod h1:TUfxEVdsvPg18p6AslUXFoLdpED4oBnGwyqk3dV1XzM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d h1:uvYuEyMHKNt+lT4K3bN6fGswmK8qSvcreM3BwjDh+y4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d/go.mod h1:+Bk1OCOj40wS2hwAMA+aCW9ypzm63QTBBHp6lQ3p+9M=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230911183012-2d3300fd4832 h1:o4LtQxebKIJ4vkzyhtD2rfUNZ20Zf0ik5YVP5E7G7VE=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20230911183012-2d3300fd4832/go.mod h1:+Bk1OCOj40wS2hwAMA+aCW9ypzm63QTBBHp6lQ3p+9M=
 google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
 google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=


### PR DESCRIPTION
see https://github.com/grpc-ecosystem/grpc-gateway

testing like this:
```
$ docker run --rm -it -p 50051:50051 -p 8082:8082 cad70904c875
2023/09/12 01:30:20 Server listening at [::]:50051
2023/09/12 01:30:20 HTTP Server listening at 8082
...

$ curl -kL http://localhost:8082/v1
{"code":5,"message":"Not Found","details":[]}

$ curl -kL http://localhost:8082/v1/inventory/1/inventory/2
this produces full correct response
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
