### PR TITLE
refactor(common): move inventory to separate folder

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,7 @@ import (
 	"net/http"
 	"time"
 
-	pc "github.com/opiproject/opi-api/common/v1/gen/go"
+	pc "github.com/opiproject/opi-api/inventory/v1/gen/go"
 	"github.com/opiproject/opi-smbios-bridge/pkg/inventory"
 
 	"google.golang.org/grpc"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0
 	github.com/jaypipes/ghw v0.12.0
-	github.com/opiproject/opi-api v0.0.0-20231012135448-00e9f8d63cb4
+	github.com/opiproject/opi-api v0.0.0-20231016162146-d81cc5ee60d4
 	google.golang.org/grpc v1.58.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/opiproject/opi-api v0.0.0-20231009064235-b166668c8a86 h1:lHZuWCy8La/n
 github.com/opiproject/opi-api v0.0.0-20231009064235-b166668c8a86/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 github.com/opiproject/opi-api v0.0.0-20231012135448-00e9f8d63cb4 h1:dvvG4m7/+P8rmQUO5LqxQij1Q5XmKjJ6LXnQ0+LFWvg=
 github.com/opiproject/opi-api v0.0.0-20231012135448-00e9f8d63cb4/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
+github.com/opiproject/opi-api v0.0.0-20231016162146-d81cc5ee60d4 h1:q20p6Hg4Un2St+vnw1b1sMSYTDg6bK0PbNrMb5xi7QU=
+github.com/opiproject/opi-api v0.0.0-20231016162146-d81cc5ee60d4/go.mod h1:92pv4ulvvPMuxCJ9ND3aYbmBfEMLx0VCjpkiR7ZTqPY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -10,7 +10,7 @@ import (
 	"log"
 
 	"github.com/jaypipes/ghw"
-	pc "github.com/opiproject/opi-api/common/v1/gen/go"
+	pc "github.com/opiproject/opi-api/inventory/v1/gen/go"
 )
 
 // Server contains inventory related OPI services

--- a/pkg/inventory/inventory_test.go
+++ b/pkg/inventory/inventory_test.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
-	pc "github.com/opiproject/opi-api/common/v1/gen/go"
+	pc "github.com/opiproject/opi-api/inventory/v1/gen/go"
 )
 
 func dialer() func(context.Context, string) (net.Conn, error) {


### PR DESCRIPTION
Moving inventory from common to separate folder to allow for future additions such as capabilities protobuf and to support the autogeneration of protobuf files using 'buf'

blocked by https://github.com/opiproject/opi-api/pull/386